### PR TITLE
Fix: Add SSM Session Manager and KMS permissions to IAM role

### DIFF
--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -86,10 +86,7 @@ resource "aws_iam_role_policy" "monitoring" {
           "ssm:GetParameter",
           "ssm:GetParameters"
         ]
-        Resource = [
-          "arn:aws:ec2:::volume/*", 
-          "arn:aws:logs:::log-group:*"
-        ]
+        Resource = "*"
       },
       {
         Effect = "Allow"
@@ -102,9 +99,34 @@ resource "aws_iam_role_policy" "monitoring" {
           aws_s3_bucket.monitoring_backups.arn,
           "${aws_s3_bucket.monitoring_backups.arn}/*"
         ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ssmmessages:CreateControlChannel",
+          "ssmmessages:CreateDataChannel",
+          "ssmmessages:OpenControlChannel",
+          "ssmmessages:OpenDataChannel",
+          "ssm:UpdateInstanceInformation"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "kms:Decrypt",
+          "kms:DescribeKey"
+        ]
+        Resource = "*"
       }
     ]
   })
+}
+
+# Attach AWS managed policy for SSM
+resource "aws_iam_role_policy_attachment" "ssm_managed_policy" {
+  role       = aws_iam_role.monitoring.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
 
 resource "aws_iam_instance_profile" "monitoring" {


### PR DESCRIPTION
Issue: SSM Session Manager connection fails with KMS decrypt error
Error: AccessDeniedException - not authorized to perform kms:Decrypt

Root cause: IAM role missing required permissions for SSM Session Manager

Changes:
1. Added SSM Session Manager permissions:
   - ssmmessages:CreateControlChannel
   - ssmmessages:CreateDataChannel
   - ssmmessages:OpenControlChannel
   - ssmmessages:OpenDataChannel
   - ssm:UpdateInstanceInformation

2. Added KMS permissions:
   - kms:Decrypt (required for Session Manager encryption)
   - kms:DescribeKey

3. Attached AWS managed policy:
   - AmazonSSMManagedInstanceCore (best practice for SSM)

4. Fixed Resource ARNs:
   - Changed specific ARNs to '*' for CloudWatch/SSM (required scope)

This allows SSM Session Manager connections to work properly with encrypted sessions.